### PR TITLE
ci(tests): add GitHub Actions badge reporting test results

### DIFF
--- a/.github/workflows/SQLServerTest.yml
+++ b/.github/workflows/SQLServerTest.yml
@@ -39,9 +39,56 @@ jobs:
           done
 
       - name: Run CloudTest project tests
-        env: 
-          GITHUB_ACTION: "true"
-        run: dotnet test CloudTests/CloudTests.csproj --no-build --verbosity normal
+        id: run-tests
+        run: |
+          # Run tests and save output to a file
+          dotnet test CloudTests/CloudTests.csproj --no-build --verbosity normal > test_output.txt 2>&1
+      
+          # Initialize counters
+          PASSED=0
+          FAILED=0
+      
+          # Loop through each line and extract numbers
+          while IFS= read -r line; do
+              if [[ "$line" =~ Passed:\ ([0-9]+) ]]; then
+                  PASSED=${BASH_REMATCH[1]}
+              fi
+              if [[ "$line" =~ Failed:\ ([0-9]+) ]]; then
+                  FAILED=${BASH_REMATCH[1]}
+              fi
+          done < test_output.txt
+      
+          # Output the entire test output
+          cat test_output.txt
+      
+          # Export as GitHub Actions outputs
+          echo "passed=$PASSED" >> $GITHUB_OUTPUT
+          echo "failed=$FAILED" >> $GITHUB_OUTPUT
+
+      - name: Update test badge in Gist
+        env:
+          GIST_TOKEN: ${{ secrets.GIST_TOKEN }}
+          GIST_ID: 4ac1300861898e7568dbec51c70bd24b
+        run: |
+          # Create badge JSON locally (example)
+          if [ "${{ steps.run-tests.outputs.failed }}" -eq "0" ]; then
+            COLOR="green"
+          else
+            COLOR="red"
+          fi
+          MESSAGE="${{ steps.run-tests.outputs.passed }} passed, ${{ steps.run-tests.outputs.failed }} failed"
+          echo "{\"schemaVersion\":1,\"label\":\"GitHub Action Tests\",\"message\":\"$MESSAGE\",\"color\":\"$COLOR\"}" > test-badge.json
+
+          # Prepare JSON payload for updating the gist
+          GIST_PAYLOAD=$(jq -n --arg content "$(cat test-badge.json)" \
+            '{ files: { "test-badge.json": { "content": $content } } }')
+
+          # Update the Gist
+          curl -s -X PATCH \
+            -H "Authorization: token $GIST_TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            https://api.github.com/gists/$GIST_ID \
+            -d "$GIST_PAYLOAD"
 
       - name: Dump SQL Server logs on failure
         if: failure()

--- a/README.md
+++ b/README.md
@@ -7,7 +7,11 @@
 <br>
 [![GitHub milestone details](https://img.shields.io/github/milestones/progress/williamowen65/atlas-the-public-think-tank/5)](https://github.com/williamowen65/atlas-the-public-think-tank/milestone/5)
 <br>
+
+
 # Atlas - The Public Think Tank  
+
+![Tests](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/williamowen65/4ac1300861898e7568dbec51c70bd24b/raw/test-badge.json)
 
 > Atlas is a social media platform designed to connect innovative thinkers with problem-solvers. It provides a space for users to share ideas, collaborate on projects, and engage in meaningful discussions around issues and solutions. The platform aims to foster a community of forward-thinkers who can collectively address complex challenges.
 


### PR DESCRIPTION
- Updated GitHub Action to write test results to a GitHub Gist
- Added shield.io badge to README showing passing/failing test count
- Improves visibility of test status directly in the repo