### PR TITLE
ci(tests): restrict badge generation to main branch

### DIFF
--- a/.github/workflows/SQLServerTest.yml
+++ b/.github/workflows/SQLServerTest.yml
@@ -65,7 +65,8 @@ jobs:
           echo "passed=$PASSED" >> $GITHUB_OUTPUT
           echo "failed=$FAILED" >> $GITHUB_OUTPUT
 
-      - name: Update test badge in Gist
+      - name: Update test badge in Gist if testing on main branch
+        if: github.ref == 'refs/heads/main'
         env:
           GIST_TOKEN: ${{ secrets.GIST_TOKEN }}
           GIST_ID: 4ac1300861898e7568dbec51c70bd24b


### PR DESCRIPTION
Update GitHub Action that generates the test badge in the Gist so it only runs when commits are pushed to the main branch. This prevents badge updates from feature or experimental branches, ensuring the badge always reflects the state of the main branch.