### PR TITLE
chore(server-logs): configure logging levels for cache and general logs

### DIFF
--- a/www.thepublicthinktank.com/Views/Shared/_Layout.cshtml
+++ b/www.thepublicthinktank.com/Views/Shared/_Layout.cshtml
@@ -9,7 +9,6 @@
 
 @{
 
-    Console.WriteLine("t");
 }
 
 <!DOCTYPE html>

--- a/www.thepublicthinktank.com/appsettings.Development.json
+++ b/www.thepublicthinktank.com/appsettings.Development.json
@@ -1,6 +1,6 @@
 {
   "ConnectionStrings": {
-    "DefaultConnection": "Server=(localdb)\\mssqllocaldb;Database=atlas_the_public_think_tank-seed-data-update;Trusted_Connection=True;MultipleActiveResultSets=true"
+    "DefaultConnection": "Server=(localdb)\\mssqllocaldb;Database=atlas_the_public_think_tank-main-branch;Trusted_Connection=True;MultipleActiveResultSets=true"
   },
-  "ApplySeedData": true
+  "ApplySeedData": false
 }

--- a/www.thepublicthinktank.com/appsettings.json
+++ b/www.thepublicthinktank.com/appsettings.json
@@ -5,9 +5,8 @@
   "APPLICATIONINSIGHTS_CONNECTION_STRING": "APPLICATIONINSIGHTS_CONNECTION_STRING Set in environment-variables or secrets file",
   "Logging": {
     "LogLevel": {
-      "Default": "Information",
-      "Microsoft.AspNetCore": "Information",
-      "Microsoft.EntityFrameworkCore.Database.Command": "Warning"
+      "Default": "Warning",
+      "CacheLog": "Information"
     },
     "Conditional": {
       "Filters": false


### PR DESCRIPTION
- Sets Default log level to Warning, so only warnings, errors, and critical messages from all categories are logged by default.
- Sets CacheLog log level to Information, so all cache-related info messages (Info, Warning, Error, Critical) are logged.
- Filters out general Info logs from ASP.NET Core and other frameworks while keeping detailed cache logs visible.