### PR TITLE
feat(content-pages): expand main content by default and add sticky tab title

### DIFF
--- a/www.thepublicthinktank.com/Views/Issue/ReadIssue.cshtml
+++ b/www.thepublicthinktank.com/Views/Issue/ReadIssue.cshtml
@@ -16,12 +16,16 @@
     @* @await Html.PartialAsync("~/Views/Issue/_issue-author-tag.cshtml", Model) *@
 
     @* @Html.Partial("~/Views/Issue/_issue-page-post.cshtml", Model) *@
-    @await Html.PartialAsync("~/Views/Issue/_issue-card.cshtml", Model.Issue)
+    @await Html.PartialAsync(
+        "~/Views/Issue/_issue-card.cshtml", 
+        Model.Issue, 
+        new ViewDataDictionary(ViewData) { { "defaultExpand", true } }
+    )
 
 
    
 
-    <nav class=" position-sticky bg-body" style="top:var(--header-height); z-index:11">
+    <nav class="sub-content-tab-bar position-sticky bg-body" style="top:var(--header-height); z-index:11">
         <div class="d-flex">
 
         <div class="nav nav-tabs flex-grow-1 text-nowrap overflow-x-scroll overflow-y-hidden" style="flex-wrap: revert;" id="nav-tab" role="tablist">

--- a/www.thepublicthinktank.com/Views/Issue/_issue-card.cshtml
+++ b/www.thepublicthinktank.com/Views/Issue/_issue-card.cshtml
@@ -9,13 +9,14 @@
 @model Issue_ReadVM
 @{
     Boolean IsContentLong = true;
-   
+
+    bool isDefaultExpand = ViewData["defaultExpand"] is bool b && b;
 }
 
 
 @await Html.PartialAsync("~/Views/Issue/_issue-author-tag.cshtml", Model)
 
-<div class="card mb-3 issue-card " id="@Model.IssueID" data-content-type="issue">
+<div class="card mb-3 issue-card @(isDefaultExpand ? "expanded-by-default expanded" : "")" id="@Model.IssueID" data-content-type="issue">
     <div class="card-content position-relative  mb-2">
             @await Html.PartialAsync("~/Views/Issue/_issue-card-sticky-header.cshtml", Model)
 
@@ -50,7 +51,7 @@
 
             </div>
             @await Html.PartialAsync("~/Views/Shared/Components/_scope-composite.cshtml", Model.Scope)
-            <p class="mx-2 mb-2 truncate-multiline text-collapsible-target issue-content" style="white-space: pre-wrap">@Model.Content</p>
+        <p class="mx-2 mb-2 @(isDefaultExpand ? "" : "truncate-multiline") text-collapsible-target issue-content" style="white-space: pre-wrap">@Model.Content</p>
 
 
             @* @if (Model.Categories != null && Model.Categories.Any())
@@ -62,7 +63,7 @@
                         }
                     </div>
                 } *@
-            @if (IsContentLong)
+            @if (IsContentLong && !isDefaultExpand)
             {
                 <div class="expand-button-spacer" style="height: 30px;"></div>
 
@@ -78,7 +79,7 @@
     <div class="card-footer d-flex justify-content-between">
         <div class="" id="card-@Model.IssueID-footer-alert">
         </div>
-          @if (IsContentLong)
+          @if (IsContentLong && !isDefaultExpand)
         {
             <div class="card-collapse-toggle-container position-absolute" style="
         left: 50%;
@@ -88,7 +89,7 @@
             </div>
         }
         <div class="">
-             @if (IsContentLong)
+             @if (IsContentLong && !isDefaultExpand)
         {
                 <button class="card-minimize-toggle btn btn-secondary btn-sm mx-auto d-none">Minimize</button>
         }

--- a/www.thepublicthinktank.com/Views/Solution/ReadSolution.cshtml
+++ b/www.thepublicthinktank.com/Views/Solution/ReadSolution.cshtml
@@ -13,9 +13,13 @@
 
 <div class="container mt-3  ">
 
-    @await Html.PartialAsync("~/Views/Solution/_solution-card.cshtml", Model.Solution) 
+    @await Html.PartialAsync(
+        "~/Views/Solution/_solution-card.cshtml",
+        Model.Solution,
+        new ViewDataDictionary(ViewData) { { "defaultExpand", true } }
+    )
 
-    <nav class="d-flex position-sticky bg-body" style="top:var(--header-height); z-index:11">
+    <nav class="d-flex sub-content-tab-bar position-sticky bg-body" style="top:var(--header-height); z-index:11">
         <div class="nav nav-tabs flex-grow-1 text-nowrap overflow-x-scroll overflow-y-hidden" style="flex-wrap: revert;" id="nav-tab" role="tablist">
 
             <button class="nav-link active" id="comments-tab" data-bs-toggle="tab" data-bs-target="#issue-comments" type="button" role="tab" aria-controls="nav-profile" aria-selected="false">

--- a/www.thepublicthinktank.com/Views/Solution/_solution-card.cshtml
+++ b/www.thepublicthinktank.com/Views/Solution/_solution-card.cshtml
@@ -8,12 +8,14 @@
 
 @{
     Boolean IsContentLong = true;
+
+    bool isDefaultExpand = ViewData["defaultExpand"] is bool b && b;
 }
 
 @await Html.PartialAsync("~/Views/Solution/_solution-author-tag.cshtml", Model)
 
 
-<div class="card mb-3 solution-card" id="@Model.SolutionID" data-content-type="solution">
+<div class="card mb-3 solution-card @(isDefaultExpand ? "expanded-by-default expanded" : "")" id="@Model.SolutionID" data-content-type="solution">
     <div class="card-content position-relative mb-2">
         @await Html.PartialAsync("~/Views/Solution/_solution-card-sticky-header.cshtml", Model)
         <div class="dial-container" style="float:left">
@@ -43,7 +45,7 @@
         </div>
 
         @await Html.PartialAsync("~/Views/Shared/Components/_scope-composite.cshtml", Model.Scope)
-        <p class="mx-2 mb-2 truncate-multiline text-collapsible-target" style="white-space: pre-wrap">@Model.Content</p>
+        <p class="mx-2 mb-2 @(isDefaultExpand ? "" : "truncate-multiline") text-collapsible-target" style="white-space: pre-wrap">@Model.Content</p>
 
         @* @if (Model.Categories != null && Model.Categories.Any())
         {
@@ -55,7 +57,7 @@
             </div>
         } *@
         
-        @if (IsContentLong)
+        @if (IsContentLong && !isDefaultExpand)
         {
             <div class="expand-button-spacer" style="height: 30px;"></div>
         }
@@ -66,7 +68,7 @@
     <div class="card-footer d-flex justify-content-between">
         <div class="" id="card-@Model.SolutionID-footer-alert">
         </div>
-        @if (IsContentLong)
+        @if (IsContentLong && !isDefaultExpand)
         {
             <div class="card-collapse-toggle-container position-absolute" style="
                 left: 50%;
@@ -76,7 +78,7 @@
             </div>
         }
         <div class="">
-            @if (IsContentLong)
+            @if (IsContentLong && !isDefaultExpand)
             {
                 <button class="card-minimize-toggle btn btn-secondary btn-sm mx-auto d-none">Minimize</button>
             }

--- a/www.thepublicthinktank.com/appsettings.Development.json
+++ b/www.thepublicthinktank.com/appsettings.Development.json
@@ -1,6 +1,6 @@
 {
   "ConnectionStrings": {
-    "DefaultConnection": "Server=(localdb)\\mssqllocaldb;Database=atlas_the_public_think_tank-seed-data-update;Trusted_Connection=True;MultipleActiveResultSets=true"
+    "DefaultConnection": "Server=(localdb)\\mssqllocaldb;Database=atlas_the_public_think_tank;Trusted_Connection=True;MultipleActiveResultSets=true"
   },
   "ApplySeedData": true
 }

--- a/www.thepublicthinktank.com/wwwroot/css/read-issue.css
+++ b/www.thepublicthinktank.com/wwwroot/css/read-issue.css
@@ -136,19 +136,33 @@
     border-top: 0;
 }
 
+:root {
+    --sub-content-tab-bar: 57px;
+}
+
+.sub-content-tab-bar {
+    height: var(--sub-content-tab-bar);
+}
+
 .card.solution-card.expanded .card-sticky-header,
 .card.issue-card.expanded .card-sticky-header {
     position: sticky;
     top: var(--header-height);
     visibility: visible;
-
 }
+.tab-pane .card.solution-card.expanded .card-sticky-header,
+.tab-pane .card.issue-card.expanded .card-sticky-header {
+    top: calc(var(--header-height) + var(--sub-content-tab-bar));
+}
+
 
 :root {
     --solution-bg: #03ca03; /* Light mode green */
     --issue-bg: #f8d7da
     /* Add other light mode variables here */
 }
+
+
 
 [data-bs-theme="dark"] {
     --solution-bg: #006600; /* Dark mode green */
@@ -178,3 +192,4 @@
     position: relative;
     background: linear-gradient(to bottom, var(--bs-body-bg) 0%, var(--bs-body-bg) 70%, rgba(255,255,255,0) 100%);
 }
+


### PR DESCRIPTION
- Main content sections now expanded by default on content pages
- Added CSS to keep tab pane title sticky while scrolling